### PR TITLE
Add capability to revoke all active session

### DIFF
--- a/aws-commands/info.json
+++ b/aws-commands/info.json
@@ -5,9 +5,9 @@
   "publisher": "Fortinet",
   "cs_approved": false,
   "cs_compatible": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "category": "IT Services",
-  "help_online": "https://github.com/fortinet-fortisoar/connector-aws-commands/blob/release/1.0.0/docs/AWSCommandsConnectorDoc.md",
+  "help_online": "https://github.com/fortinet-fortisoar/connector-aws-commands/blob/release/1.0.1/docs/AWSCommandsConnectorDoc.md",
   "icon_small_name": "AWS_small.png",
   "icon_large_name": "AWS_large.png",
   "configuration": {
@@ -3841,6 +3841,25 @@
         "env": {},
         "message": ""
       }
-    }
+    },
+    {
+            "title": "Revoke all active sessions",
+            "operation": "revoke_all_active_sessions",
+            "description": "If you choose Revoke active sessions, IAM attaches an inline policy named AWSRevokeOlderSessions to this role. This policy denies access to all currently active sessions for this role. You can continue to create new sessions based on this role. If you need to undo this action later, you can remove the inline policy.",
+            "parameters": [
+                {
+                    "title": "Role Name",
+                    "type": "text",
+                    "name": "roleName",
+                    "required": true,
+                    "visible": true,
+                    "editable": true,
+                    "value": "",
+                    "tooltip": "Provide a Role Name from which you want to revoke all active sessions.",
+                }
+            ],
+            "open": false,
+            "category": "remediation"
+        }
   ]
 }

--- a/aws-commands/operations.py
+++ b/aws-commands/operations.py
@@ -14,6 +14,7 @@ from connectors.core.connector import get_logger, ConnectorError
 from .utils import _get_aws_client, _change_date_format, _is_mfa_device, _get_user_policies, _get_user_groups_details, \
     _get_temp_credentials, _get_list_from_str_or_list, _get_group_ids, _get_aws_resource, \
     _get_cli_environment, _run_aws_cli
+from datetime import datetime, timedelta
 
 logger = get_logger('aws-commands')
 TEMP_CRED_ENDPOINT = 'http://169.254.169.254/latest/meta-data/iam/security-credentials/{}'
@@ -507,6 +508,39 @@ def delete_security_group(config, params):
         logger.exception(Err)
         raise ConnectorError(Err)
 
+def revoke_all_active_sessions(config, params):
+    try:
+        role_name = params.get('roleName')
+        lead_seconds = int(params.get('lead_seconds', 30))
+        iam = _get_aws_client(config, params, 'iam')
+        cutoff = datetime.utcnow() + timedelta(seconds=lead_seconds)
+        cutoff_iso = cutoff.strftime("%Y-%m-%dT%H:%M:%SZ")
+        policy_doc = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Deny",
+                    "Action": ["*"],
+                    "Resource": ["*"],
+                    "Condition": {
+                        "DateLessThan": {
+                            "aws:TokenIssueTime": cutoff_iso
+                        }
+                    }
+                }
+            ]
+        }
+        iam.put_role_policy(
+            RoleName=role_name,
+            PolicyName="AWSRevokeOlderSessions",
+            PolicyDocument=json.dumps(policy_doc)
+        )
+        logger.info(f"Attached AWSRevokeOlderSessions to role '{role_name}' with cutoff {cutoff_iso}")
+        return {"status": "success", "role_name": role_name, "cutoff": cutoff_iso, "policy": policy_doc}
+    except Exception as Err:
+        logger.exception(Err)
+        raise ConnectorError(Err)
+
 
 aws_operations = {
     'generic_command': generic_command,
@@ -549,4 +583,6 @@ aws_operations = {
     'delete_network_acl': delete_network_acl,
     'delete_network_acl_rule': delete_network_acl_rule,
     'add_network_acl_rule': add_network_acl_rule,
+
+    'revoke_all_active_sessions': revoke_all_active_sessions
 }


### PR DESCRIPTION
### Descriptions:
This PR add the capability to revoke all active sesions related to a AWS role. This can be handy for IR teams if e.g. temporary access credentials have been leaked or abused. AWS provides this capability within the IAM Console but not directly via API.
Further information on the capability can be founde in the [AWS Docs](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_revoke-sessions.html)

#### Fix:
- The action `revoke_all_active_sessions` has been added to the `info.json`
- The related connector code has been added to `operations.py`

#### Affected Actions:
- [ ] All
- [ ] Check Health
- [X] Other Actions

#### QA Impact:
- [ ] `full`
- [ ] Test what is prescribed in the Mantis Ticket
- [ ] Regression Impacts
- [ ] Regression Area X
- [ ] Ensure that platform dependencies remain unaffected

#### UTCs:
- [ ] Connector installation verified
- [ ] Connector logo verified
- [ ] Check health verified
- [ ] Docs link verified
- [ ] Actions and Playbooks list verified
- [ ] Playbook tags verified
- [ ] All playbooks are in info mode verified
- [ ] All playbooks are in inactive mode verified
- [ ] Ingestion playbooks are verified
- [ ] Verified platform dependencies remain unaffected

#### Pytest Test Cases: (If applicable)
- [ ] Attach the test report
